### PR TITLE
Check for formatting during the compile lifecycle phase

### DIFF
--- a/src/main/java/com/coveo/Check.java
+++ b/src/main/java/com/coveo/Check.java
@@ -17,7 +17,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * Check mojo that will ensure all files are formatted. If some files are not formatted, an
  * exception is thrown.
  */
-@Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
+@Mojo(name = "check", defaultPhase = LifecyclePhase.COMPILE, threadSafe = true)
 public class Check extends AbstractFMT {
 
   /** Flag to display or not the files that are not compliant. */


### PR DESCRIPTION
If there are non-complying files, `check` fails the build after all of the previous phases are completed, which often involves running several tests. In order to save time, it would be useful to move this to the `compile` lifecycle phase.

What do you think?