### PR TITLE
Allow skipping of sourceDirectory or testSourceDirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ For example, you may prefer that the `check` goal is performed in an earlier pha
 
 `skipSortingImports` is whether the plugin should skip sorting imports.
 
+`skipSourceDirectory` is whether the plugin should skip formatting/checking the `sourceDirectory`. It defaults to `false`.
+
+`skipTestSourceDirectory` is whether the plugin should skip formatting/checking the `testSourceDirectory`. It defaults to `false`.
+
 `style` sets the formatter style to be _google_ or _aosp_. By default this is 'google'. Projects using Android conventions may prefer `aosp`.
 
 example:
@@ -117,6 +121,8 @@ example:
                     <param>some/other/dir</param>
                 </additionalSourceDirectories>
                 <skip>false</skip>
+                <skipSourceDirectory>false</skipSourceDirectory>
+                <skipTestSourceDirectory>false</skipTestSourceDirectory>
                 <skipSortingImports>false</skipSortingImports>
                 <style>google</style>
             </configuration>

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -54,6 +54,12 @@ public abstract class AbstractFMT extends AbstractMojo {
   @Parameter(defaultValue = "false", property = "fmt.skip")
   private boolean skip = false;
 
+  @Parameter(defaultValue = "false", property = "skipSourceDirectory")
+  private boolean skipSourceDirectory = false;
+
+  @Parameter(defaultValue = "false", property = "skipTestSourceDirectory")
+  private boolean skipTestSourceDirectory = false;
+
   @Parameter(defaultValue = "false", property = "skipSortingImports")
   private boolean skipSortingImports = false;
 
@@ -82,12 +88,12 @@ public abstract class AbstractFMT extends AbstractMojo {
       getLog().info("Skipping sorting imports");
     }
     List<File> directoriesToFormat = new ArrayList<>();
-    if (sourceDirectory.exists()) {
+    if (sourceDirectory.exists() && !skipSourceDirectory) {
       directoriesToFormat.add(sourceDirectory);
     } else {
       handleMissingDirectory("Source", sourceDirectory);
     }
-    if (testSourceDirectory.exists()) {
+    if (testSourceDirectory.exists() && !skipTestSourceDirectory) {
       directoriesToFormat.add(testSourceDirectory);
     } else {
       handleMissingDirectory("Test source", testSourceDirectory);

--- a/src/test/java/com/spotify/fmt/FMTTest.java
+++ b/src/test/java/com/spotify/fmt/FMTTest.java
@@ -25,8 +25,24 @@ public class FMTTest {
   }
 
   @Test
+  public void skipSource() throws Exception {
+    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("skipsourcedirectory"), FORMAT);
+    fmt.execute();
+
+    assertThat(fmt.getFilesProcessed()).hasSize(1);
+  }
+
+  @Test
   public void withoutTestSources() throws Exception {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("notestsource"), FORMAT);
+    fmt.execute();
+
+    assertThat(fmt.getFilesProcessed()).hasSize(2);
+  }
+
+  @Test
+  public void skipTestSources() throws Exception {
+    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("skiptestsourcedirectory"), FORMAT);
     fmt.execute();
 
     assertThat(fmt.getFilesProcessed()).hasSize(2);
@@ -146,6 +162,20 @@ public class FMTTest {
   @Test(expected = MojoFailureException.class)
   public void checkFailsWhenNotFormatted() throws Exception {
     Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("check_notformatted"), CHECK);
+    check.execute();
+  }
+
+  @Test
+  public void checkSucceedsWhenSkipSourceDirectory() throws Exception {
+    Check check =
+        (Check) mojoRule.lookupConfiguredMojo(loadPom("check_skipsourcedirectory"), CHECK);
+    check.execute();
+  }
+
+  @Test
+  public void checkSucceedsWhenSkipTestSourceDirectory() throws Exception {
+    Check check =
+        (Check) mojoRule.lookupConfiguredMojo(loadPom("check_skiptestsourcedirectory"), CHECK);
     check.execute();
   }
 

--- a/src/test/java/com/spotify/fmt/FMTTest.java
+++ b/src/test/java/com/spotify/fmt/FMTTest.java
@@ -35,7 +35,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("skipsourcedirectory"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).hasSize(1);
+    assertThat(fmt.getResult().processedFiles()).hasSize(1);
   }
 
   @Test
@@ -51,7 +51,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("skiptestsourcedirectory"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).hasSize(2);
+    assertThat(fmt.getResult().processedFiles()).hasSize(2);
   }
 
   @Test

--- a/src/test/java/com/spotify/fmt/FMTTest.java
+++ b/src/test/java/com/spotify/fmt/FMTTest.java
@@ -32,7 +32,7 @@ public class FMTTest {
 
   @Test
   public void skipSource() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("skipsourcedirectory"), FORMAT);
+    FMT fmt = loadMojo("skipsourcedirectory", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(1);
@@ -48,7 +48,7 @@ public class FMTTest {
 
   @Test
   public void skipTestSources() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("skiptestsourcedirectory"), FORMAT);
+    FMT fmt = loadMojo("skiptestsourcedirectory", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(2);
@@ -217,15 +217,13 @@ public class FMTTest {
 
   @Test
   public void checkSucceedsWhenSkipSourceDirectory() throws Exception {
-    Check check =
-        (Check) mojoRule.lookupConfiguredMojo(loadPom("check_skipsourcedirectory"), CHECK);
+    Check check = loadMojo("check_skipsourcedirectory", CHECK);
     check.execute();
   }
 
   @Test
   public void checkSucceedsWhenSkipTestSourceDirectory() throws Exception {
-    Check check =
-        (Check) mojoRule.lookupConfiguredMojo(loadPom("check_skiptestsourcedirectory"), CHECK);
+    Check check = loadMojo("check_skiptestsourcedirectory", CHECK);
     check.execute();
   }
 

--- a/src/test/resources/check_skipsourcedirectory/invoker.properties
+++ b/src/test/resources/check_skipsourcedirectory/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:check

--- a/src/test/resources/check_skipsourcedirectory/pom.xml
+++ b/src/test/resources/check_skipsourcedirectory/pom.xml
@@ -21,7 +21,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.coveo</groupId>
+                <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>2.12</version>
                 <configuration>

--- a/src/test/resources/check_skipsourcedirectory/pom.xml
+++ b/src/test/resources/check_skipsourcedirectory/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.12</version>
+                <configuration>
+                    <skipSourceDirectory>true</skipSourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/check_skipsourcedirectory/src/main/java/HelloWorld1.java
+++ b/src/test/resources/check_skipsourcedirectory/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/check_skipsourcedirectory/src/main/java/HelloWorld2.java
+++ b/src/test/resources/check_skipsourcedirectory/src/main/java/HelloWorld2.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/check_skipsourcedirectory/src/test/java/HelloWorldTest.java
+++ b/src/test/resources/check_skipsourcedirectory/src/test/java/HelloWorldTest.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorldTest {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/check_skiptestsourcedirectory/invoker.properties
+++ b/src/test/resources/check_skiptestsourcedirectory/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:check

--- a/src/test/resources/check_skiptestsourcedirectory/pom.xml
+++ b/src/test/resources/check_skiptestsourcedirectory/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.12</version>
+                <configuration>
+                    <skipTestSourceDirectory>true</skipTestSourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/check_skiptestsourcedirectory/pom.xml
+++ b/src/test/resources/check_skiptestsourcedirectory/pom.xml
@@ -21,7 +21,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.coveo</groupId>
+                <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>2.12</version>
                 <configuration>

--- a/src/test/resources/check_skiptestsourcedirectory/src/main/java/HelloWorld1.java
+++ b/src/test/resources/check_skiptestsourcedirectory/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/check_skiptestsourcedirectory/src/main/java/HelloWorld2.java
+++ b/src/test/resources/check_skiptestsourcedirectory/src/main/java/HelloWorld2.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/check_skiptestsourcedirectory/src/test/java/HelloWorldTest.java
+++ b/src/test/resources/check_skiptestsourcedirectory/src/test/java/HelloWorldTest.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorldTest {
+public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/skipsourcedirectory/invoker.properties
+++ b/src/test/resources/skipsourcedirectory/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:format

--- a/src/test/resources/skipsourcedirectory/pom.xml
+++ b/src/test/resources/skipsourcedirectory/pom.xml
@@ -21,7 +21,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.coveo</groupId>
+                <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>2.12</version>
                 <configuration>

--- a/src/test/resources/skipsourcedirectory/pom.xml
+++ b/src/test/resources/skipsourcedirectory/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.12</version>
+                <configuration>
+                    <skipSourceDirectory>true</skipSourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/skipsourcedirectory/src/main/java/HelloWorld1.java
+++ b/src/test/resources/skipsourcedirectory/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/skipsourcedirectory/src/main/java/HelloWorld2.java
+++ b/src/test/resources/skipsourcedirectory/src/main/java/HelloWorld2.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/skipsourcedirectory/src/test/java/HelloWorldTest.java
+++ b/src/test/resources/skipsourcedirectory/src/test/java/HelloWorldTest.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorldTest {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/skiptestsourcedirectory/invoker.properties
+++ b/src/test/resources/skiptestsourcedirectory/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:format

--- a/src/test/resources/skiptestsourcedirectory/pom.xml
+++ b/src/test/resources/skiptestsourcedirectory/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.12</version>
+                <configuration>
+                    <skipTestSourceDirectory>true</skipTestSourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/skiptestsourcedirectory/pom.xml
+++ b/src/test/resources/skiptestsourcedirectory/pom.xml
@@ -21,7 +21,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.coveo</groupId>
+                <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>2.12</version>
                 <configuration>

--- a/src/test/resources/skiptestsourcedirectory/src/main/java/HelloWorld1.java
+++ b/src/test/resources/skiptestsourcedirectory/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/skiptestsourcedirectory/src/main/java/HelloWorld2.java
+++ b/src/test/resources/skiptestsourcedirectory/src/main/java/HelloWorld2.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/skiptestsourcedirectory/src/test/java/HelloWorldTest.java
+++ b/src/test/resources/skiptestsourcedirectory/src/test/java/HelloWorldTest.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorldTest {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}


### PR DESCRIPTION
Fixes spotify/fmt-maven-plugin#31

Adds 2 extra configuration options controlling whether to skip relevant
directories:

- skipSourceDirectory
- skipTestSourceDirectory

Tests added:

- check_skipsourcedirectory: Tests that sourceDirectory is skipped
  for check goal when skipSourceDirectory is true.
  sourceDirectory includes unformatted code so it would fail if not
  skipped.
- check_skiptestsourcedirectory: Tests that testSourceDirectory is
  skipped for check goal when skipTestSourceDirectory is true.
  testSourceDirectory includes unformatted code so it would
  fail if not skipped.
- skipsourcedirectory: Tests that sourceDirectory files are not formatted
  with format goal when skipSourceDirectory is true.
- skiptestsourcedirectory: Tests that testSourceDirectory files are not
  formatted with format goal when skipTestSourceDirectory is true.