### PR TITLE
Update README to refer to 2.14 (2.13 does not exist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To have your sources automatically formatted on each build, add to your pom.xml:
             <plugin>
                 <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.13</version>
+                <version>2.14</version>
                 <executions>
                     <execution>
                         <goals>
@@ -45,7 +45,7 @@ If you prefer, you can only check formatting at build time using the `check` goa
             <plugin>
                 <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.13</version>
+                <version>2.14</version>
                 <executions>
                     <execution>
                         <goals>
@@ -106,7 +106,7 @@ example:
         <plugin>
             <groupId>com.spotify.fmt</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.13</version>
+            <version>2.14</version>
             <configuration>
                 <sourceDirectory>some/source/directory</sourceDirectory>
                 <testSourceDirectory>some/test/directory</testSourceDirectory>
@@ -149,7 +149,7 @@ example to not display the non-compliant files:
         <plugin>
             <groupId>com.spotify.fmt</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.13</version>
+            <version>2.14</version>
             <configuration>
                 <displayFiles>false</displayFiles>
             </configuration>
@@ -172,7 +172,7 @@ example to limit the display up to 10 files
         <plugin>
             <groupId>com.spotify.fmt</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.13</version>
+            <version>2.14</version>
             <configuration>
                 <displayLimit>10</displayLimit>
             </configuration>


### PR DESCRIPTION
Nice to see the first com.spotify.fmt release has been made! 🥳 

I was just switching our project over to the com.spotify.fmt version but noticed the README refers to 2.13 but this is the last coveo version, README should now refer to 2.14