### PR TITLE
Upgrade fmt-maven-plugin 2.14 -> 2.15 and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To have your sources automatically formatted on each build, add to your pom.xml:
             <plugin>
                 <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.14</version>
+                <version>VERSION</version>
                 <executions>
                     <execution>
                         <goals>
@@ -45,7 +45,7 @@ If you prefer, you can only check formatting at build time using the `check` goa
             <plugin>
                 <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.14</version>
+                <version>VERSION</version>
                 <executions>
                     <execution>
                         <goals>
@@ -106,7 +106,7 @@ example:
         <plugin>
             <groupId>com.spotify.fmt</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.14</version>
+            <version>VERSION</version>
             <configuration>
                 <sourceDirectory>some/source/directory</sourceDirectory>
                 <testSourceDirectory>some/test/directory</testSourceDirectory>
@@ -149,7 +149,7 @@ example to not display the non-compliant files:
         <plugin>
             <groupId>com.spotify.fmt</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.14</version>
+            <version>VERSION</version>
             <configuration>
                 <displayFiles>false</displayFiles>
             </configuration>
@@ -172,7 +172,7 @@ example to limit the display up to 10 files
         <plugin>
             <groupId>com.spotify.fmt</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.14</version>
+            <version>VERSION</version>
             <configuration>
                 <displayLimit>10</displayLimit>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
             <plugin>
                 <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.14</version>
+                <version>2.15</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
In the `README` the version is changed from 2.14 -> `VERSION`, based on [this comment](https://github.com/spotify/fmt-maven-plugin/pull/135#issuecomment-1049690496).

