### PR TITLE
run formatter in fork - run on java 16+ without --add-exports flags

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
- -Dtodo.remove.once.plugin.can.fork.with.args.builtin=true --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/README.md
+++ b/README.md
@@ -199,14 +199,6 @@ You can pass parameters via standard `-D` syntax.
 
 `-Dfmt.skip` is whether the plugin should skip the operation.
 
-### Using with Java 16+ and Maven
-
-Since the JDK is more restrictive since version 16 you need to pass some [parameters](https://github.com/google/google-java-format#jdk-16) to the JVM to run the Google Java Formatter. To do so add the file  `.mvn/jvm.config` under your project's root directory with the following contents:
-
-```
---add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED 
-```
-
 ### Using with Java 8
 
 Starting from version 1.8, Google Java Formatter requires Java 11 to run. Incidently, all versions of this plugin starting from 2.10 inclusively also require this Java version to properly function. The 2.9.x release branch is the most up-to-date version that still runs on Java 8.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ For example, you may prefer that the `check` goal is performed in an earlier pha
 
 `skipSortingImports` is whether the plugin should skip sorting imports.
 
-`style` sets the formatter style to be _google_ or _aosp_. By default this is 'google'. Projects using Android conventions may prefer `aosp`.
+`style` sets the formatter style to be `google` or `aosp`. By default this is `google`. Projects using Android conventions may prefer `aosp`.
+
+`forkMode` lets you specify whether to run google-java-format in a fork or in-process. Also adds JVM arguments when needed. Value `default` will fork when JDK 16+ is detected, `never` runs in-process, regardless of JDK version and `always` will always fork.
 
 example:
 ```xml

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,13 @@
         </dependency>
 
         <dependency>
+            <groupId>io.norberg</groupId>
+            <artifactId>auto-matter</artifactId>
+            <version>0.25.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -188,8 +188,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -243,15 +243,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>jdk17+</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <properties>
-                <!-- TODO: Remove this once google-java-fmt supports 17 or the plugin supports forking and run with these args built-in -->
-                <argLine> --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</argLine>
-            </properties>
-        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,9 @@
                 <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>2.15</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -58,7 +58,7 @@ public abstract class AbstractFMT extends AbstractMojo {
   private Map<String, Artifact> pluginArtifactMap;
 
   /**
-   * Option to specify whether to run google-java-format in a fork or in-process. Can be {@code default}, {@code never} and {@code always.
+   * Option to specify whether to run google-java-format in a fork or in-process. Can be {@code default}, {@code never} and {@code always}.
    * The {@code default} (which is the default) will fork when JDK 16+ is detected.
    * The {@code never} will never fork and instead run in-process, regardless of JDK version.
    * The {@code always} will always fork, regardless of JDK version.<br>

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -150,10 +150,10 @@ public abstract class AbstractFMT extends AbstractMojo {
 
   private boolean shouldFork() {
     switch (forkMode) {
-      case "never":
-        return false;
       case "default":
         return hasModuleSystem();
+      case "never":
+        return false;
       case "always":
         return true;
       default:

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -153,7 +153,7 @@ public abstract class AbstractFMT extends AbstractMojo {
   private boolean shouldFork() {
     switch (forkMode) {
       case "default":
-        return stronglyEncapsulatedByDefault();
+        return javaRuntimeStronglyEncapsulatesByDefault();
       case "never":
         return false;
       case "always":
@@ -203,12 +203,12 @@ public abstract class AbstractFMT extends AbstractMojo {
   protected abstract String getProcessingLabel();
 
   @VisibleForTesting
-  static boolean stronglyEncapsulatedByDefault() {
+  static boolean javaRuntimeStronglyEncapsulatesByDefault() {
     return Runtime.version().compareTo(Runtime.Version.parse("16")) >= 0;
   }
 
   private List<String> javaArgs() {
-    if (!stronglyEncapsulatedByDefault()) {
+    if (!javaRuntimeStronglyEncapsulatesByDefault()) {
       return Collections.emptyList();
     }
 

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -56,7 +56,7 @@ public abstract class AbstractFMT extends AbstractMojo {
 
   /**
    * Option to specify whether to run google-java-format in a fork or in-process. Can be {@code
-   * default}, {@code never} and {@code always}.
+   * default}, {@code never} and {@code always}. Also adds JVM arguments when needed.
    *
    * <p>Specifying {@code default} (which is the default) will fork when JDK 16+ is detected.
    * Specifying {@code never} will never fork and instead run in-process, regardless of JDK version.
@@ -217,7 +217,7 @@ public abstract class AbstractFMT extends AbstractMojo {
       return Collections.emptyList();
     }
 
-    // https://github.com/google/google-java-format/blob/13ca73ebbfa86f6aca5f86be16e6829de6d5014c/pom.xml#L238
+    // https://github.com/google/google-java-format/blame/13ca73ebbfa86f6aca5f86be16e6829de6d5014c/pom.xml#L238
     return Arrays.asList(
         "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
         "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -153,7 +153,7 @@ public abstract class AbstractFMT extends AbstractMojo {
   private boolean shouldFork() {
     switch (forkMode) {
       case "default":
-        return hasModuleSystem();
+        return stronglyEncapsulatedByDefault();
       case "never":
         return false;
       case "always":
@@ -202,18 +202,13 @@ public abstract class AbstractFMT extends AbstractMojo {
    */
   protected abstract String getProcessingLabel();
 
-  /** Is this JDK 16+? */
-  private boolean hasModuleSystem() {
-    try {
-      Class.forName("java.lang.Module");
-      return true;
-    } catch (ClassNotFoundException e) {
-      return false;
-    }
+  @VisibleForTesting
+  static boolean stronglyEncapsulatedByDefault() {
+    return Runtime.version().compareTo(Runtime.Version.parse("16")) >= 0;
   }
 
   private List<String> javaArgs() {
-    if (!hasModuleSystem()) {
+    if (!stronglyEncapsulatedByDefault()) {
       return Collections.emptyList();
     }
 

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -58,10 +58,12 @@ public abstract class AbstractFMT extends AbstractMojo {
   private Map<String, Artifact> pluginArtifactMap;
 
   /**
-   * Option to specify whether to run google-java-format in a fork or in-process. Can be {@code default}, {@code never} and {@code always}.
-   * The {@code default} (which is the default) will fork when JDK 16+ is detected.
-   * The {@code never} will never fork and instead run in-process, regardless of JDK version.
-   * The {@code always} will always fork, regardless of JDK version.<br>
+   * Option to specify whether to run google-java-format in a fork or in-process. Can be {@code
+   * default}, {@code never} and {@code always}.
+   *
+   * <p>Specifying {@code default} (which is the default) will fork when JDK 16+ is detected.
+   * Specifying {@code never} will never fork and instead run in-process, regardless of JDK version.
+   * Specifying {@code always} will always fork, regardless of JDK version.<br>
    */
   @Parameter(defaultValue = "default", property = "fmt.forkMode")
   String forkMode;

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -63,7 +63,7 @@ public abstract class AbstractFMT extends AbstractMojo {
    * Specifying {@code always} will always fork, regardless of JDK version.<br>
    */
   @Parameter(defaultValue = "default", property = "fmt.forkMode")
-  String forkMode;
+  private String forkMode;
 
   @Parameter(property = "plugin.artifactMap", required = true, readonly = true)
   private Map<String, Artifact> pluginArtifactMap;

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -54,9 +54,6 @@ public abstract class AbstractFMT extends AbstractMojo {
   @Parameter(defaultValue = "google", property = "style")
   private String style;
 
-  @Parameter(property = "plugin.artifactMap", required = true, readonly = true)
-  private Map<String, Artifact> pluginArtifactMap;
-
   /**
    * Option to specify whether to run google-java-format in a fork or in-process. Can be {@code
    * default}, {@code never} and {@code always}.
@@ -67,6 +64,9 @@ public abstract class AbstractFMT extends AbstractMojo {
    */
   @Parameter(defaultValue = "default", property = "fmt.forkMode")
   String forkMode;
+
+  @Parameter(property = "plugin.artifactMap", required = true, readonly = true)
+  private Map<String, Artifact> pluginArtifactMap;
 
   /**
    * Whether to use the classpath from the java.class.path property when forking. Only intended for

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -217,12 +217,18 @@ public abstract class AbstractFMT extends AbstractMojo {
       return Collections.emptyList();
     }
 
+    // https://github.com/google/google-java-format/blob/13ca73ebbfa86f6aca5f86be16e6829de6d5014c/pom.xml#L238
     return Arrays.asList(
         "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
         "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports", "jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
         "--add-exports", "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports", "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
         "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-        "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED");
+        "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED");
   }
 
   private static class FormattingCallable implements SerializableCallable<FormattingResult> {

--- a/src/main/java/com/spotify/fmt/Check.java
+++ b/src/main/java/com/spotify/fmt/Check.java
@@ -34,7 +34,7 @@ public class Check extends AbstractFMT {
   protected void postExecute(FormattingResult result) throws MojoFailureException {
     if (!result.nonComplyingFiles().isEmpty()) {
       String message =
-          "Found " + result.nonComplyingFiles().stream() + " non-complying files, failing build";
+          "Found " + result.nonComplyingFiles().size() + " non-complying files, failing build";
       getLog().error(message);
       getLog()
           .error("To fix formatting errors, run \"mvn com.spotify.fmt:fmt-maven-plugin:format\"");

--- a/src/main/java/com/spotify/fmt/FMT.java
+++ b/src/main/java/com/spotify/fmt/FMT.java
@@ -1,10 +1,5 @@
 package com.spotify.fmt;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.CharSink;
-import com.google.common.io.Files;
-import java.io.File;
-import java.io.IOException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
@@ -17,16 +12,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES, threadSafe = true)
 public class FMT extends AbstractFMT {
 
-  /**
-   * Hook called when the processd file is not compliant with the formatter.
-   *
-   * @param file the file that is not compliant
-   * @param formatted the corresponding formatted of the file.
-   */
   @Override
-  protected void onNonComplyingFile(File file, String formatted) throws IOException {
-    CharSink sink = Files.asCharSink(file, Charsets.UTF_8);
-    sink.write(formatted);
+  protected boolean shouldWriteReformattedFiles() {
+    return true;
   }
 
   /**

--- a/src/main/java/com/spotify/fmt/ForkingExecutor.java
+++ b/src/main/java/com/spotify/fmt/ForkingExecutor.java
@@ -1,0 +1,371 @@
+package com.spotify.fmt;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.lang.management.ManagementFactory;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * An executor that executes a method in a sub-process JVM.
+ *
+ * <p>The function, its result and any thrown exception must be serializable as serialization is
+ * used to transport these between the processes.
+ *
+ * <p>Adapted from
+ * https://github.com/spotify/flo/blob/91d2e546bc8fa8e6fee9bc8c6dd484d87db3b0af/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
+ */
+class ForkingExecutor implements Closeable {
+
+  private final org.apache.maven.plugin.logging.Log log;
+
+  private final List<Execution<?>> executions = new ArrayList<>();
+
+  private Map<String, String> environment = Collections.emptyMap();
+  private List<String> javaArgs = Collections.emptyList();
+
+  public ForkingExecutor(Log log) {
+    this.log = log;
+  }
+
+  ForkingExecutor environment(Map<String, String> environment) {
+    this.environment = new HashMap<>(environment);
+    return this;
+  }
+
+  ForkingExecutor javaArgs(String... javaArgs) {
+    return javaArgs(Arrays.asList(javaArgs));
+  }
+
+  ForkingExecutor javaArgs(List<String> javaArgs) {
+    this.javaArgs = new ArrayList<>(javaArgs);
+    return this;
+  }
+
+  /**
+   * Execute a function in a sub-process.
+   *
+   * @param f The function to execute.
+   * @return The return value of the function. Any exception thrown by the function the will be
+   *     propagated and re-thrown.
+   * @throws IOException if
+   */
+  <T> T execute(SerializableCallable<T> f) throws IOException {
+    try (final Execution<T> execution = new Execution<>(f)) {
+      executions.add(execution);
+      execution.start();
+      return execution.waitFor();
+    }
+  }
+
+  @Override
+  public void close() {
+    executions.forEach(Execution::close);
+  }
+
+  private class Execution<T> implements Closeable {
+
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    private final Path tempdir = Files.createTempDirectory("fmt-maven-plugin");
+
+    private final Path workdir = Files.createDirectory(tempdir.resolve("workdir"));
+
+    private final Path closureFile = tempdir.resolve("closure");
+    private final Path resultFile = tempdir.resolve("result");
+    private final Path errorFile = tempdir.resolve("error");
+
+    private final String home = System.getProperty("java.home");
+    private final String classPath = System.getProperty("java.class.path");
+    private final Path java = Paths.get(home, "bin", "java").toAbsolutePath().normalize();
+
+    private final SerializableCallable<T> f;
+
+    private Process process;
+
+    Execution(SerializableCallable<T> f) throws IOException {
+      this.f = Objects.requireNonNull(f);
+    }
+
+    void start() {
+      if (process != null) {
+        throw new IllegalStateException();
+      }
+      log.debug("serializing closure");
+      try {
+        Serialization.serialize(f, closureFile);
+      } catch (SerializationException e) {
+        throw new RuntimeException("Failed to serialize closure", e);
+      }
+
+      final String absoluteClassPath =
+          Arrays.stream(classPath.split(File.pathSeparator))
+              .map(cp -> Paths.get(cp).toAbsolutePath().toString())
+              .collect(Collectors.joining(File.pathSeparator));
+
+      final ProcessBuilder processBuilder =
+          new ProcessBuilder(java.toString(), "-cp", absoluteClassPath).directory(workdir.toFile());
+
+      // Propagate -Xmx and -D.
+      ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+          .filter(s -> s.startsWith("-Xmx") || s.startsWith("-D"))
+          .forEach(processBuilder.command()::add);
+
+      // Custom jvm args
+      javaArgs.forEach(processBuilder.command()::add);
+
+      // Trampoline arguments
+      processBuilder.command().add(Trampoline.class.getName());
+      processBuilder.command().add(closureFile.toString());
+      processBuilder.command().add(resultFile.toString());
+      processBuilder.command().add(errorFile.toString());
+
+      processBuilder.environment().putAll(environment);
+
+      log.debug(
+          MessageFormat.format(
+              "Starting subprocess: environment={0}, command={1}, directory={2}",
+              processBuilder.environment(), processBuilder.command(), processBuilder.directory()));
+      try {
+        process = processBuilder.start();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+
+      // Copy std{err,out} line by line to avoid interleaving and corrupting line contents.
+      executor.submit(() -> copyLines(process.getInputStream(), System.out));
+      executor.submit(() -> copyLines(process.getErrorStream(), System.err));
+    }
+
+    T waitFor() {
+      if (process == null) {
+        throw new IllegalStateException();
+      }
+      log.debug("Waiting for subprocess exit");
+      final int exitValue;
+      try {
+        exitValue = process.waitFor();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      } finally {
+        process.destroyForcibly();
+      }
+
+      log.debug("Subprocess exited: " + exitValue);
+      if (exitValue != 0) {
+        throw new RuntimeException("Subprocess failed: " + process.exitValue());
+      }
+
+      if (Files.exists(errorFile)) {
+        // Failed
+        log.debug("Subprocess exited with error file");
+        final Throwable error;
+        try {
+          error = Serialization.deserialize(errorFile);
+        } catch (SerializationException e) {
+          throw new RuntimeException("Failed to deserialize error", e);
+        }
+        if (error instanceof Error) {
+          throw (Error) error;
+        } else if (error instanceof RuntimeException) {
+          throw (RuntimeException) error;
+        } else {
+          throw new RuntimeException(error);
+        }
+      } else {
+        // Success
+        log.debug("Subprocess exited with result file");
+        final T result;
+        try {
+          result = Serialization.deserialize(resultFile);
+        } catch (SerializationException e) {
+          throw new RuntimeException("Failed to deserialize result", e);
+        }
+        return result;
+      }
+    }
+
+    @Override
+    public void close() {
+      if (process != null) {
+        process.destroyForcibly();
+        process = null;
+      }
+      executor.shutdown();
+      tryDeleteDir(tempdir);
+    }
+  }
+
+  private void tryDeleteDir(Path path) {
+    try {
+      deleteDir(path);
+    } catch (IOException e) {
+      log.warn("Failed to delete directory: " + path, e);
+    }
+  }
+
+  private static void deleteDir(Path path) throws IOException {
+    try {
+      Files.walkFileTree(
+          path,
+          new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                throws IOException {
+              try {
+                Files.delete(file);
+              } catch (NoSuchFileException ignore) {
+              }
+              return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+                throws IOException {
+              try {
+                Files.delete(dir);
+              } catch (NoSuchFileException ignore) {
+              }
+              return FileVisitResult.CONTINUE;
+            }
+          });
+    } catch (NoSuchFileException ignore) {
+    }
+  }
+
+  private void copyLines(InputStream in, PrintStream out) {
+    final BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+    try {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        out.println(line);
+      }
+    } catch (IOException e) {
+      log.error("Caught exception during stream copy", e);
+    }
+  }
+
+  private static class Trampoline {
+
+    private static org.apache.maven.plugin.logging.Log log = Logging.getLog();
+
+    private static class Watchdog extends Thread {
+
+      Watchdog() {
+        setDaemon(true);
+      }
+
+      @Override
+      public void run() {
+        // Wait for parent to exit.
+        try {
+          while (true) {
+            int c = System.in.read();
+            if (c == -1) {
+              break;
+            }
+          }
+        } catch (IOException e) {
+          log.error("watchdog failed", e);
+        }
+        log.debug("child process exiting");
+        // Exit with non-zero status code to skip shutdown hooks
+        System.exit(-1);
+      }
+    }
+
+    public static void main(String... args) {
+      log.debug("child process started: args=" + Arrays.asList(args));
+      final Watchdog watchdog = new Watchdog();
+      watchdog.start();
+
+      if (args.length != 3) {
+        log.error("args.length != 3");
+        System.exit(3);
+        return;
+      }
+      final Path closureFile;
+      final Path resultFile;
+      final Path errorFile;
+      try {
+        closureFile = Paths.get(args[0]);
+        resultFile = Paths.get(args[1]);
+        errorFile = Paths.get(args[2]);
+      } catch (InvalidPathException e) {
+        log.error("Failed to get file path", e);
+        System.exit(4);
+        return;
+      }
+
+      run(closureFile, resultFile, errorFile);
+    }
+
+    private static void run(Path closureFile, Path resultFile, Path errorFile) {
+      log.debug("deserializing closure: " + closureFile);
+      final SerializableCallable<?> fn;
+      try {
+        fn = Serialization.deserialize(closureFile);
+      } catch (SerializationException e) {
+        log.error("Failed to deserialize closure: " + closureFile, e);
+        System.exit(5);
+        return;
+      }
+
+      log.debug("executing closure");
+      Object result = null;
+      Throwable error = null;
+      try {
+        result = fn.call();
+      } catch (Throwable e) {
+        error = e;
+      }
+
+      if (error != null) {
+        log.debug("serializing error", error);
+        try {
+          Serialization.serialize(error, errorFile);
+        } catch (SerializationException e) {
+          log.error("failed to serialize error", e);
+          System.exit(6);
+          return;
+        }
+      } else {
+        log.debug("serializing result: " + result);
+        try {
+          Serialization.serialize(result, resultFile);
+        } catch (SerializationException e) {
+          log.error("failed to serialize result", e);
+          System.exit(7);
+          return;
+        }
+      }
+
+      System.err.flush();
+      System.exit(0);
+    }
+  }
+}

--- a/src/main/java/com/spotify/fmt/ForkingExecutor.java
+++ b/src/main/java/com/spotify/fmt/ForkingExecutor.java
@@ -83,7 +83,7 @@ class ForkingExecutor implements Closeable {
     return Arrays.asList(System.getProperty("java.class.path").split(File.pathSeparator));
   }
 
-  private List<String> excutionClassPath() {
+  private List<String> executionClassPath() {
     return withDefaultClasspath
         ? Stream.concat(configuredClasspath.stream(), defaultClasspath().stream())
             .collect(Collectors.toList())
@@ -99,7 +99,7 @@ class ForkingExecutor implements Closeable {
    * @throws IOException if
    */
   <T> T execute(SerializableCallable<T> f) throws IOException {
-    try (final Execution<T> execution = new Execution<>(excutionClassPath(), f)) {
+    try (final Execution<T> execution = new Execution<>(executionClassPath(), f)) {
       executions.add(execution);
       execution.start();
       return execution.waitFor();

--- a/src/main/java/com/spotify/fmt/ForkingExecutor.java
+++ b/src/main/java/com/spotify/fmt/ForkingExecutor.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.lang.management.ManagementFactory;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -152,11 +151,6 @@ class ForkingExecutor implements Closeable {
 
       final ProcessBuilder processBuilder =
           new ProcessBuilder(java.toString(), "-cp", classPathArg).directory(workdir.toFile());
-
-      // Propagate -Xmx and -D.
-      ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
-          .filter(s -> s.startsWith("-Xmx") || s.startsWith("-D"))
-          .forEach(processBuilder.command()::add);
 
       // Custom jvm args
       javaArgs.forEach(processBuilder.command()::add);

--- a/src/main/java/com/spotify/fmt/Formatter.java
+++ b/src/main/java/com/spotify/fmt/Formatter.java
@@ -1,0 +1,159 @@
+package com.spotify.fmt;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.CharSink;
+import com.google.common.io.CharSource;
+import com.google.googlejavaformat.java.ImportOrderer;
+import com.google.googlejavaformat.java.JavaFormatterOptions;
+import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
+import com.google.googlejavaformat.java.RemoveUnusedImports;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.maven.plugin.logging.Log;
+
+class Formatter {
+
+  private static final Log log = Logging.getLog();
+
+  private final FormattingConfiguration cfg;
+
+  private final CopyOnWriteArrayList<String> processedFiles = new CopyOnWriteArrayList<>();
+  private final CopyOnWriteArrayList<String> nonComplyingFiles = new CopyOnWriteArrayList<>();
+
+  Formatter(FormattingConfiguration cfg) {
+    this.cfg = cfg;
+  }
+
+  FormattingResult format() throws FormatterException {
+    JavaFormatterOptions.Style style = style();
+    com.google.googlejavaformat.java.Formatter formatter = getFormatter(style);
+
+    for (File directoryToFormat : cfg.directoriesToFormat()) {
+      formatSourceFilesInDirectory(directoryToFormat, formatter, style);
+    }
+
+    logNumberOfFilesProcessed();
+
+    return FormattingResult.builder()
+        .nonComplyingFiles(nonComplyingFiles)
+        .processedFiles(processedFiles)
+        .build();
+  }
+
+  public void formatSourceFilesInDirectory(
+      File directory, com.google.googlejavaformat.java.Formatter formatter, Style style)
+      throws FormatterException {
+    if (!directory.isDirectory()) {
+      log.info("Directory '" + directory + "' is not a directory. Skipping.");
+      return;
+    }
+
+    try (Stream<Path> paths = Files.walk(Paths.get(directory.getPath()))) {
+      FileFilter fileNameFilter = getFileNameFilter();
+      FileFilter pathFilter = getPathFilter();
+      long failures =
+          paths.collect(Collectors.toList()).parallelStream()
+              .filter(p -> p.toFile().exists())
+              .map(Path::toFile)
+              .filter(fileNameFilter::accept)
+              .filter(pathFilter::accept)
+              .map(file -> formatSourceFile(file, formatter, style))
+              .filter(r -> !r)
+              .count();
+
+      if (failures > 0) {
+        throw new FormatterException(
+            "There were errors when formatting files. Error count: " + failures);
+      }
+    } catch (IOException exception) {
+      throw new FormatterException(exception.getMessage());
+    }
+  }
+
+  private com.google.googlejavaformat.java.Formatter getFormatter(
+      JavaFormatterOptions.Style style) {
+    return new com.google.googlejavaformat.java.Formatter(
+        JavaFormatterOptions.builder().style(style).build());
+  }
+
+  private JavaFormatterOptions.Style style() throws FormatterException {
+    if ("aosp".equalsIgnoreCase(cfg.style())) {
+      log.debug("Using AOSP style");
+      return JavaFormatterOptions.Style.AOSP;
+    }
+    if ("google".equalsIgnoreCase(cfg.style())) {
+      log.debug("Using Google style");
+      return JavaFormatterOptions.Style.GOOGLE;
+    }
+    String message = "Unknown style '" + cfg.style() + "'. Expected 'google' or 'aosp'.";
+    log.error(message);
+    throw new FormatterException(message);
+  }
+
+  private FileFilter getFileNameFilter() {
+    if (cfg.verbose()) {
+      log.debug("Filter files on '" + cfg.filesNamePattern() + "'.");
+    }
+    return pathname -> pathname.isDirectory() || pathname.getName().matches(cfg.filesNamePattern());
+  }
+
+  private FileFilter getPathFilter() {
+    if (cfg.verbose()) {
+      log.debug("Filter paths on '" + cfg.filesPathPattern() + "'.");
+    }
+    return pathname -> pathname.isDirectory() || pathname.getPath().matches(cfg.filesPathPattern());
+  }
+
+  private boolean formatSourceFile(
+      File file, com.google.googlejavaformat.java.Formatter formatter, Style style) {
+    if (file.isDirectory()) {
+      if (cfg.verbose()) {
+        log.debug("File '" + file + "' is a directory. Skipping.");
+      }
+      return true;
+    }
+
+    if (cfg.verbose()) {
+      log.debug("Formatting '" + file + "'.");
+    }
+
+    CharSource source = com.google.common.io.Files.asCharSource(file, Charsets.UTF_8);
+    try {
+      String input = source.read();
+      String formatted = formatter.formatSource(input);
+      formatted = RemoveUnusedImports.removeUnusedImports(formatted);
+      if (!cfg.skipSortingImports()) {
+        formatted = ImportOrderer.reorderImports(formatted, style);
+      }
+      if (!input.equals(formatted)) {
+        if (cfg.writeReformattedFiles()) {
+          CharSink sink = com.google.common.io.Files.asCharSink(file, Charsets.UTF_8);
+          sink.write(formatted);
+        }
+        nonComplyingFiles.add(file.getAbsolutePath());
+      }
+      processedFiles.add(file.getAbsolutePath());
+      if (processedFiles.size() % 100 == 0) {
+        logNumberOfFilesProcessed();
+      }
+    } catch (com.google.googlejavaformat.java.FormatterException | IOException e) {
+      log.error("Failed to format file '" + file + "'.", e);
+      return false;
+    }
+    return true;
+  }
+
+  protected void logNumberOfFilesProcessed() {
+    log.info(
+        String.format(
+            "Processed %d files (%d %s).",
+            processedFiles.size(), nonComplyingFiles.size(), cfg.processingLabel()));
+  }
+}

--- a/src/main/java/com/spotify/fmt/FormatterException.java
+++ b/src/main/java/com/spotify/fmt/FormatterException.java
@@ -1,0 +1,8 @@
+package com.spotify.fmt;
+
+public class FormatterException extends RuntimeException {
+
+  public FormatterException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/spotify/fmt/FormattingConfiguration.java
+++ b/src/main/java/com/spotify/fmt/FormattingConfiguration.java
@@ -8,6 +8,8 @@ import java.util.List;
 @AutoMatter
 interface FormattingConfiguration extends Serializable {
 
+  boolean debug();
+
   String style();
 
   List<File> directoriesToFormat();

--- a/src/main/java/com/spotify/fmt/FormattingConfiguration.java
+++ b/src/main/java/com/spotify/fmt/FormattingConfiguration.java
@@ -1,0 +1,30 @@
+package com.spotify.fmt;
+
+import io.norberg.automatter.AutoMatter;
+import java.io.File;
+import java.io.Serializable;
+import java.util.List;
+
+@AutoMatter
+interface FormattingConfiguration extends Serializable {
+
+  String style();
+
+  List<File> directoriesToFormat();
+
+  boolean verbose();
+
+  String filesNamePattern();
+
+  String filesPathPattern();
+
+  boolean skipSortingImports();
+
+  boolean writeReformattedFiles();
+
+  String processingLabel();
+
+  static FormattingConfigurationBuilder builder() {
+    return new FormattingConfigurationBuilder();
+  }
+}

--- a/src/main/java/com/spotify/fmt/FormattingResult.java
+++ b/src/main/java/com/spotify/fmt/FormattingResult.java
@@ -1,0 +1,17 @@
+package com.spotify.fmt;
+
+import io.norberg.automatter.AutoMatter;
+import java.io.Serializable;
+import java.util.List;
+
+@AutoMatter
+interface FormattingResult extends Serializable {
+
+  List<String> processedFiles();
+
+  List<String> nonComplyingFiles();
+
+  static FormattingResultBuilder builder() {
+    return new FormattingResultBuilder();
+  }
+}

--- a/src/main/java/com/spotify/fmt/Logger.java
+++ b/src/main/java/com/spotify/fmt/Logger.java
@@ -1,0 +1,34 @@
+package com.spotify.fmt;
+
+import org.apache.maven.plugin.logging.SystemStreamLog;
+
+class Logger extends SystemStreamLog {
+
+  volatile boolean debug;
+
+  @Override
+  public boolean isDebugEnabled() {
+    return debug;
+  }
+
+  @Override
+  public void debug(CharSequence content) {
+    if (isDebugEnabled()) {
+      super.debug(content);
+    }
+  }
+
+  @Override
+  public void debug(CharSequence content, Throwable error) {
+    if (isDebugEnabled()) {
+      super.debug(content, error);
+    }
+  }
+
+  @Override
+  public void debug(Throwable error) {
+    if (isDebugEnabled()) {
+      super.debug(error);
+    }
+  }
+}

--- a/src/main/java/com/spotify/fmt/Logging.java
+++ b/src/main/java/com/spotify/fmt/Logging.java
@@ -1,22 +1,16 @@
 package com.spotify.fmt;
 
-import org.apache.maven.monitor.logging.DefaultLog;
 import org.apache.maven.plugin.logging.Log;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 
 class Logging {
 
-  private static volatile Log log = new DefaultLog(new ConsoleLogger());
+  private static final Logger log = new Logger();
 
   static Log getLog() {
     return log;
   }
 
   public static void configure(boolean debugLoggingEnabled) {
-    log =
-        new DefaultLog(
-            new ConsoleLogger(
-                debugLoggingEnabled ? Logger.LEVEL_DEBUG : Logger.LEVEL_INFO, "console"));
+    log.debug = debugLoggingEnabled;
   }
 }

--- a/src/main/java/com/spotify/fmt/Logging.java
+++ b/src/main/java/com/spotify/fmt/Logging.java
@@ -1,0 +1,22 @@
+package com.spotify.fmt;
+
+import org.apache.maven.monitor.logging.DefaultLog;
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+
+class Logging {
+
+  private static volatile Log log = new DefaultLog(new ConsoleLogger());
+
+  static Log getLog() {
+    return log;
+  }
+
+  public static void configure(boolean debugLoggingEnabled) {
+    log =
+        new DefaultLog(
+            new ConsoleLogger(
+                debugLoggingEnabled ? Logger.LEVEL_DEBUG : Logger.LEVEL_INFO, "console"));
+  }
+}

--- a/src/main/java/com/spotify/fmt/SerializableCallable.java
+++ b/src/main/java/com/spotify/fmt/SerializableCallable.java
@@ -1,0 +1,6 @@
+package com.spotify.fmt;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+
+interface SerializableCallable<T> extends Callable<T>, Serializable {}

--- a/src/main/java/com/spotify/fmt/Serialization.java
+++ b/src/main/java/com/spotify/fmt/Serialization.java
@@ -1,23 +1,3 @@
-/*-
- * -\-\-
- * Flo Workflow Definition
- * --
- * Copyright (C) 2016 - 2018 Spotify AB
- * --
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * -/-/-
- */
-
 package com.spotify.fmt;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;

--- a/src/main/java/com/spotify/fmt/Serialization.java
+++ b/src/main/java/com/spotify/fmt/Serialization.java
@@ -1,0 +1,77 @@
+/*-
+ * -\-\-
+ * Flo Workflow Definition
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.fmt;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class Serialization {
+
+  static {
+    // Best effort. Hope that ObjectOutputStream has not been loaded yet.
+    System.setProperty("sun.io.serialization.extendedDebugInfo", "true");
+  }
+
+  private Serialization() {
+    throw new UnsupportedOperationException();
+  }
+
+  static void serialize(Object object, Path file) throws SerializationException {
+    try (final OutputStream os = Files.newOutputStream(file, WRITE, CREATE_NEW)) {
+      serialize(object, os);
+    } catch (IOException e) {
+      throw new SerializationException("Serialization failed", e);
+    }
+  }
+
+  static void serialize(Object object, OutputStream outputStream) throws SerializationException {
+    try (ObjectOutputStream oos = new ObjectOutputStream(outputStream)) {
+      oos.writeObject(object);
+    } catch (Throwable t) {
+      throw new SerializationException("Serialization failed", t);
+    }
+  }
+
+  static <T> T deserialize(Path filePath) throws SerializationException {
+    try {
+      return deserialize(Files.newInputStream(filePath));
+    } catch (IOException e) {
+      throw new SerializationException("Deserialization failed", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  static <T> T deserialize(InputStream inputStream) throws SerializationException {
+    try (ObjectInputStream ois = new ObjectInputStream(inputStream)) {
+      return (T) ois.readObject();
+    } catch (Throwable t) {
+      throw new SerializationException("Deserialization failed", t);
+    }
+  }
+}

--- a/src/main/java/com/spotify/fmt/SerializationException.java
+++ b/src/main/java/com/spotify/fmt/SerializationException.java
@@ -1,0 +1,28 @@
+/*-
+ * -\-\-
+ * Flo Workflow Definition
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.fmt;
+
+class SerializationException extends Exception {
+
+  public SerializationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/spotify/fmt/SerializationException.java
+++ b/src/main/java/com/spotify/fmt/SerializationException.java
@@ -1,23 +1,3 @@
-/*-
- * -\-\-
- * Flo Workflow Definition
- * --
- * Copyright (C) 2016 - 2018 Spotify AB
- * --
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * -/-/-
- */
-
 package com.spotify.fmt;
 
 class SerializationException extends Exception {

--- a/src/test/java/com/spotify/fmt/FMTTest.java
+++ b/src/test/java/com/spotify/fmt/FMTTest.java
@@ -18,7 +18,7 @@ public class FMTTest {
 
   @Test
   public void noSource() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("nosource"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "nosource", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).isEmpty();
@@ -26,7 +26,7 @@ public class FMTTest {
 
   @Test
   public void withoutTestSources() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("notestsource"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "notestsource", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(2);
@@ -34,7 +34,7 @@ public class FMTTest {
 
   @Test
   public void withOnlyTestSources() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("onlytestsources"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "onlytestsources", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(1);
@@ -42,7 +42,7 @@ public class FMTTest {
 
   @Test
   public void withAllTypesOfSources() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("simple"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "simple", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(3);
@@ -50,7 +50,7 @@ public class FMTTest {
 
   @Test
   public void withAllTypesOfSourcesWithAospStyleSpecified() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("simple_aosp"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "simple_aosp", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(3);
@@ -64,7 +64,7 @@ public class FMTTest {
 
   @Test
   public void withAllTypesOfSourcesWithGoogleStyleSpecified() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("simple_google"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "simple_google", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(3);
@@ -78,7 +78,7 @@ public class FMTTest {
 
   @Test
   public void failOnUnknownFolderDoesNotFailWhenEverythingIsThere() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("failonerrorwithsources"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "failonerrorwithsources", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).isNotEmpty();
@@ -86,19 +86,19 @@ public class FMTTest {
 
   @Test(expected = MojoFailureException.class)
   public void failOnUnknownFolderFailsWhenAFolderIsMissing() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("failonerrormissingsources"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "failonerrormissingsources", FORMAT);
     fmt.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void failOnUnknownStyle() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("failonunknownstyle"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "failonunknownstyle", FORMAT);
     fmt.execute();
   }
 
   @Test
   public void canAddAdditionalFolders() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("additionalfolders"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "additionalfolders", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(8);
@@ -106,7 +106,7 @@ public class FMTTest {
 
   @Test
   public void withOnlyAvajFiles() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("onlyavajsources"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "onlyavajsources", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(1);
@@ -114,58 +114,66 @@ public class FMTTest {
 
   @Test(expected = MojoFailureException.class)
   public void validateOnlyFailsWhenNotFormatted() throws Exception {
-    Check check =
-        (Check) mojoRule.lookupConfiguredMojo(loadPom("validateonly_notformatted"), CHECK);
+    Check check = loadMojo(Check.class, "validateonly_notformatted", CHECK);
     check.execute();
   }
 
   @Test
   public void validateOnlySucceedsWhenFormatted() throws Exception {
-    Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("validateonly_formatted"), CHECK);
+    Check check = loadMojo(Check.class, "validateonly_formatted", CHECK);
     check.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void withUnusedImports() throws Exception {
-    Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("importunused"), CHECK);
+    Check check = loadMojo(Check.class, "importunused", CHECK);
     check.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void withUnsortedImports() throws Exception {
-    Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("importunsorted"), CHECK);
+    Check check = loadMojo(Check.class, "importunsorted", CHECK);
     check.execute();
   }
 
   @Test
   public void withCleanImports() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("importclean"), FORMAT);
+    FMT fmt = loadMojo(FMT.class, "importclean", FORMAT);
     fmt.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void checkFailsWhenNotFormatted() throws Exception {
-    Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("check_notformatted"), CHECK);
+    Check check = loadMojo(Check.class, "check_notformatted", CHECK);
     check.execute();
   }
 
   @Test
   public void checkSucceedsWhenFormatted() throws Exception {
-    Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("check_formatted"), CHECK);
+    Check check = loadMojo(Check.class, "check_formatted", CHECK);
     check.execute();
   }
 
   @Test
   public void checkSucceedsWhenNotFormattedButIgnored() throws Exception {
-    Check check =
-        (Check) mojoRule.lookupConfiguredMojo(loadPom("check_notformatted_ignored"), CHECK);
+    Check check = loadMojo(Check.class, "check_notformatted_ignored", CHECK);
     check.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void checkFailsWhenFormattingFails() throws Exception {
-    Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("failed_formatting"), CHECK);
+    Check check = loadMojo(Check.class, "failed_formatting", CHECK);
     check.execute();
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends AbstractFMT> T loadMojo(Class<T> cls, String pomFilePath, String goal)
+      throws Exception {
+    File pomFile = loadPom(pomFilePath);
+    T fmt = (T) mojoRule.lookupConfiguredMojo(pomFile, goal);
+    // Required for forking to work in unit tests where ${plugin.artifactMap} is not populated.
+    fmt.forkWithDefaultClasspath = true;
+    return fmt;
   }
 
   private File loadPom(String folderName) {

--- a/src/test/java/com/spotify/fmt/FMTTest.java
+++ b/src/test/java/com/spotify/fmt/FMTTest.java
@@ -172,7 +172,7 @@ public class FMTTest {
     File pomFile = loadPom(pomFilePath);
     T fmt = (T) mojoRule.lookupConfiguredMojo(pomFile, goal);
     // Required for forking to work in unit tests where ${plugin.artifactMap} is not populated.
-    fmt.forkWithDefaultClasspath = true;
+    fmt.useDefaultClasspathWhenForking = true;
     return fmt;
   }
 

--- a/src/test/java/com/spotify/fmt/FMTTest.java
+++ b/src/test/java/com/spotify/fmt/FMTTest.java
@@ -18,7 +18,7 @@ public class FMTTest {
 
   @Test
   public void noSource() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "nosource", FORMAT);
+    FMT fmt = loadMojo("nosource", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).isEmpty();
@@ -26,7 +26,7 @@ public class FMTTest {
 
   @Test
   public void withoutTestSources() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "notestsource", FORMAT);
+    FMT fmt = loadMojo("notestsource", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(2);
@@ -34,7 +34,7 @@ public class FMTTest {
 
   @Test
   public void withOnlyTestSources() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "onlytestsources", FORMAT);
+    FMT fmt = loadMojo("onlytestsources", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(1);
@@ -42,7 +42,7 @@ public class FMTTest {
 
   @Test
   public void withAllTypesOfSources() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "simple", FORMAT);
+    FMT fmt = loadMojo("simple", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(3);
@@ -50,7 +50,7 @@ public class FMTTest {
 
   @Test
   public void withAllTypesOfSourcesWithAospStyleSpecified() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "simple_aosp", FORMAT);
+    FMT fmt = loadMojo("simple_aosp", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(3);
@@ -64,7 +64,7 @@ public class FMTTest {
 
   @Test
   public void withAllTypesOfSourcesWithGoogleStyleSpecified() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "simple_google", FORMAT);
+    FMT fmt = loadMojo("simple_google", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(3);
@@ -78,7 +78,7 @@ public class FMTTest {
 
   @Test
   public void failOnUnknownFolderDoesNotFailWhenEverythingIsThere() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "failonerrorwithsources", FORMAT);
+    FMT fmt = loadMojo("failonerrorwithsources", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).isNotEmpty();
@@ -86,19 +86,19 @@ public class FMTTest {
 
   @Test(expected = MojoFailureException.class)
   public void failOnUnknownFolderFailsWhenAFolderIsMissing() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "failonerrormissingsources", FORMAT);
+    FMT fmt = loadMojo("failonerrormissingsources", FORMAT);
     fmt.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void failOnUnknownStyle() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "failonunknownstyle", FORMAT);
+    FMT fmt = loadMojo("failonunknownstyle", FORMAT);
     fmt.execute();
   }
 
   @Test
   public void canAddAdditionalFolders() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "additionalfolders", FORMAT);
+    FMT fmt = loadMojo("additionalfolders", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(8);
@@ -106,7 +106,7 @@ public class FMTTest {
 
   @Test
   public void withOnlyAvajFiles() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "onlyavajsources", FORMAT);
+    FMT fmt = loadMojo("onlyavajsources", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(1);
@@ -114,61 +114,60 @@ public class FMTTest {
 
   @Test(expected = MojoFailureException.class)
   public void validateOnlyFailsWhenNotFormatted() throws Exception {
-    Check check = loadMojo(Check.class, "validateonly_notformatted", CHECK);
+    Check check = loadMojo("validateonly_notformatted", CHECK);
     check.execute();
   }
 
   @Test
   public void validateOnlySucceedsWhenFormatted() throws Exception {
-    Check check = loadMojo(Check.class, "validateonly_formatted", CHECK);
+    Check check = loadMojo("validateonly_formatted", CHECK);
     check.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void withUnusedImports() throws Exception {
-    Check check = loadMojo(Check.class, "importunused", CHECK);
+    Check check = loadMojo("importunused", CHECK);
     check.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void withUnsortedImports() throws Exception {
-    Check check = loadMojo(Check.class, "importunsorted", CHECK);
+    Check check = loadMojo("importunsorted", CHECK);
     check.execute();
   }
 
   @Test
   public void withCleanImports() throws Exception {
-    FMT fmt = loadMojo(FMT.class, "importclean", FORMAT);
+    FMT fmt = loadMojo("importclean", FORMAT);
     fmt.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void checkFailsWhenNotFormatted() throws Exception {
-    Check check = loadMojo(Check.class, "check_notformatted", CHECK);
+    Check check = loadMojo("check_notformatted", CHECK);
     check.execute();
   }
 
   @Test
   public void checkSucceedsWhenFormatted() throws Exception {
-    Check check = loadMojo(Check.class, "check_formatted", CHECK);
+    Check check = loadMojo("check_formatted", CHECK);
     check.execute();
   }
 
   @Test
   public void checkSucceedsWhenNotFormattedButIgnored() throws Exception {
-    Check check = loadMojo(Check.class, "check_notformatted_ignored", CHECK);
+    Check check = loadMojo("check_notformatted_ignored", CHECK);
     check.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void checkFailsWhenFormattingFails() throws Exception {
-    Check check = loadMojo(Check.class, "failed_formatting", CHECK);
+    Check check = loadMojo("failed_formatting", CHECK);
     check.execute();
   }
 
   @SuppressWarnings("unchecked")
-  private <T extends AbstractFMT> T loadMojo(Class<T> cls, String pomFilePath, String goal)
-      throws Exception {
+  private <T extends AbstractFMT> T loadMojo(String pomFilePath, String goal) throws Exception {
     File pomFile = loadPom(pomFilePath);
     T fmt = (T) mojoRule.lookupConfiguredMojo(pomFile, goal);
     // Required for forking to work in unit tests where ${plugin.artifactMap} is not populated.

--- a/src/test/java/com/spotify/fmt/FMTTest.java
+++ b/src/test/java/com/spotify/fmt/FMTTest.java
@@ -1,6 +1,9 @@
 package com.spotify.fmt;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.util.List;
@@ -107,6 +110,40 @@ public class FMTTest {
   @Test
   public void withOnlyAvajFiles() throws Exception {
     FMT fmt = loadMojo("onlyavajsources", FORMAT);
+    fmt.execute();
+
+    assertThat(fmt.getResult().processedFiles()).hasSize(1);
+  }
+
+  @Test
+  public void forkAlways() throws Exception {
+    FMT fmt = loadMojo("fork_always", FORMAT);
+    fmt.execute();
+
+    assertThat(fmt.getResult().processedFiles()).hasSize(1);
+  }
+
+  @Test
+  public void forkNeverBeforeJDK16() throws Exception {
+    assumeFalse(AbstractFMT.stronglyEncapsulatedByDefault()); // Skip if forking is needed.
+    FMT fmt = loadMojo("fork_never_beforejdk16", FORMAT);
+    fmt.execute();
+
+    assertThat(fmt.getResult().processedFiles()).hasSize(1);
+  }
+
+  @Test(expected = IllegalAccessError.class) // Could stop throwing this if google-java-format is fixed.
+  public void forkNeverAfterJDK16() throws Exception {
+    assumeTrue(AbstractFMT.stronglyEncapsulatedByDefault()); // Skip if forking is not needed.
+    FMT fmt = loadMojo("fork_never_afterjdk16", FORMAT);
+    fmt.execute();
+
+    assertThat(fmt.getResult().processedFiles()).hasSize(1);
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void unsupportedForkMode() throws Exception {
+    FMT fmt = loadMojo("unsupported_fork_mode", FORMAT);
     fmt.execute();
 
     assertThat(fmt.getResult().processedFiles()).hasSize(1);

--- a/src/test/java/com/spotify/fmt/FMTTest.java
+++ b/src/test/java/com/spotify/fmt/FMTTest.java
@@ -21,7 +21,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("nosource"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).isEmpty();
+    assertThat(fmt.getResult().processedFiles()).isEmpty();
   }
 
   @Test
@@ -29,7 +29,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("notestsource"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).hasSize(2);
+    assertThat(fmt.getResult().processedFiles()).hasSize(2);
   }
 
   @Test
@@ -37,7 +37,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("onlytestsources"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).hasSize(1);
+    assertThat(fmt.getResult().processedFiles()).hasSize(1);
   }
 
   @Test
@@ -45,7 +45,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("simple"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).hasSize(3);
+    assertThat(fmt.getResult().processedFiles()).hasSize(3);
   }
 
   @Test
@@ -53,7 +53,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("simple_aosp"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).hasSize(3);
+    assertThat(fmt.getResult().processedFiles()).hasSize(3);
 
     /* Let's make sure we formatted with AOSP using 4 spaces */
     List<String> lines =
@@ -67,7 +67,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("simple_google"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).hasSize(3);
+    assertThat(fmt.getResult().processedFiles()).hasSize(3);
 
     /* Let's make sure we formatted with Google using 2 spaces */
     List<String> lines =
@@ -81,7 +81,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("failonerrorwithsources"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).isNotEmpty();
+    assertThat(fmt.getResult().processedFiles()).isNotEmpty();
   }
 
   @Test(expected = MojoFailureException.class)
@@ -101,7 +101,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("additionalfolders"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).hasSize(8);
+    assertThat(fmt.getResult().processedFiles()).hasSize(8);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("onlyavajsources"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesProcessed()).hasSize(1);
+    assertThat(fmt.getResult().processedFiles()).hasSize(1);
   }
 
   @Test(expected = MojoFailureException.class)

--- a/src/test/java/com/spotify/fmt/FMTTest.java
+++ b/src/test/java/com/spotify/fmt/FMTTest.java
@@ -125,7 +125,7 @@ public class FMTTest {
 
   @Test
   public void forkNeverBeforeJDK16() throws Exception {
-    assumeFalse(AbstractFMT.stronglyEncapsulatedByDefault()); // Skip if forking is needed.
+    assumeFalse(AbstractFMT.javaRuntimeStronglyEncapsulatesByDefault()); // Skip if forking is needed.
     FMT fmt = loadMojo("fork_never_beforejdk16", FORMAT);
     fmt.execute();
 
@@ -134,7 +134,7 @@ public class FMTTest {
 
   @Test(expected = IllegalAccessError.class) // Could stop throwing this if google-java-format is fixed.
   public void forkNeverAfterJDK16() throws Exception {
-    assumeTrue(AbstractFMT.stronglyEncapsulatedByDefault()); // Skip if forking is not needed.
+    assumeTrue(AbstractFMT.javaRuntimeStronglyEncapsulatesByDefault()); // Skip if forking is not needed.
     FMT fmt = loadMojo("fork_never_afterjdk16", FORMAT);
     fmt.execute();
 

--- a/src/test/java/com/spotify/fmt/ForkingExecutorTest.java
+++ b/src/test/java/com/spotify/fmt/ForkingExecutorTest.java
@@ -1,0 +1,99 @@
+package com.spotify.fmt;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.maven.plugin.testing.SilentLog;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ForkingExecutorTest {
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  private ForkingExecutor forkingExecutor;
+
+  @Before
+  public void setUp() {
+    forkingExecutor = new ForkingExecutor(new SilentLog());
+  }
+
+  @Test
+  public void returnsResult() throws IOException {
+    final String result = forkingExecutor.execute(() -> "hello world!");
+    assertThat(result).isEqualTo("hello world!");
+  }
+
+  @Test
+  public void propagatesException() throws IOException {
+    exception.expect(FoobarException.class);
+    exception.expectMessage("foobar!");
+    forkingExecutor.execute(
+        () -> {
+          throw new FoobarException("foobar!");
+        });
+  }
+
+  @Test
+  public void captures() throws IOException {
+    final Map<String, String> map = new HashMap<>();
+    map.put("foo", "bar");
+    final Map<String, String> result = forkingExecutor.execute(() -> map);
+    assertThat(result).isEqualTo(map);
+  }
+
+  @Test
+  public void executesInSubprocess() throws IOException {
+    final String thisJvm = ManagementFactory.getRuntimeMXBean().getName();
+    final String subprocessJvm =
+        forkingExecutor.execute(() -> ManagementFactory.getRuntimeMXBean().getName());
+    assertThat(thisJvm).isNotEqualTo(subprocessJvm);
+  }
+
+  @Test
+  public void setsEnvironment() throws IOException {
+    final String result =
+        forkingExecutor
+            .environment(Collections.singletonMap("foo", "bar"))
+            .execute(() -> System.getenv("foo"));
+    assertThat(result).isEqualTo("bar");
+  }
+
+  @Test
+  public void setsJavaArgs() throws IOException {
+    final String result =
+        forkingExecutor.javaArgs("-Dfoo=bar").execute(() -> System.getProperty("foo"));
+    assertThat(result).isEqualTo("bar");
+  }
+
+  @Test
+  public void propagatesJavaArgs() throws IOException {
+    final String result =
+        forkingExecutor
+            .javaArgs("-Dfoo=bar")
+            .execute(
+                () -> {
+                  // Fork again with an executor without -Dfoo=bar explicitly configured
+                  try (ForkingExecutor inner = new ForkingExecutor(new SilentLog())) {
+                    // And check that -Dfoo=bar was automatically propagated
+                    return inner.execute(() -> System.getProperty("foo"));
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+    assertThat(result).isEqualTo("bar");
+  }
+
+  private static class FoobarException extends RuntimeException {
+
+    FoobarException(String message) {
+      super(message);
+    }
+  }
+}

--- a/src/test/java/com/spotify/fmt/ForkingExecutorTest.java
+++ b/src/test/java/com/spotify/fmt/ForkingExecutorTest.java
@@ -72,24 +72,6 @@ public class ForkingExecutorTest {
     assertThat(result).isEqualTo("bar");
   }
 
-  @Test
-  public void propagatesJavaArgs() throws IOException {
-    final String result =
-        forkingExecutor
-            .javaArgs("-Dfoo=bar")
-            .execute(
-                () -> {
-                  // Fork again with an executor without -Dfoo=bar explicitly configured
-                  try (ForkingExecutor inner = new ForkingExecutor(new SilentLog())) {
-                    // And check that -Dfoo=bar was automatically propagated
-                    return inner.execute(() -> System.getProperty("foo"));
-                  } catch (IOException e) {
-                    throw new RuntimeException(e);
-                  }
-                });
-    assertThat(result).isEqualTo("bar");
-  }
-
   private static class FoobarException extends RuntimeException {
 
     FoobarException(String message) {

--- a/src/test/resources/fork_always/invoker.properties
+++ b/src/test/resources/fork_always/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:format

--- a/src/test/resources/fork_always/pom.xml
+++ b/src/test/resources/fork_always/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify.fmt</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <forkMode>always</forkMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/fork_always/src/main/java/HelloWorld1.java
+++ b/src/test/resources/fork_always/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/fork_never_afterjdk16/invoker.properties
+++ b/src/test/resources/fork_never_afterjdk16/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:format
+invoker.buildResult = failure
+invoker.java.version=16+

--- a/src/test/resources/fork_never_afterjdk16/pom.xml
+++ b/src/test/resources/fork_never_afterjdk16/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify.fmt</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <forkMode>never</forkMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/fork_never_afterjdk16/src/main/java/HelloWorld1.java
+++ b/src/test/resources/fork_never_afterjdk16/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/fork_never_beforejdk16/invoker.properties
+++ b/src/test/resources/fork_never_beforejdk16/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:format
+invoker.java.version=16-

--- a/src/test/resources/fork_never_beforejdk16/pom.xml
+++ b/src/test/resources/fork_never_beforejdk16/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify.fmt</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <forkMode>never</forkMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/fork_never_beforejdk16/src/main/java/HelloWorld1.java
+++ b/src/test/resources/fork_never_beforejdk16/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/unsupported_fork_mode/invoker.properties
+++ b/src/test/resources/unsupported_fork_mode/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:format
+invoker.buildResult = failure

--- a/src/test/resources/unsupported_fork_mode/pom.xml
+++ b/src/test/resources/unsupported_fork_mode/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify.fmt</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <forkMode>foobar</forkMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/unsupported_fork_mode/src/main/java/HelloWorld1.java
+++ b/src/test/resources/unsupported_fork_mode/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}


### PR DESCRIPTION
Remove the need to add a `.mvn/jvm.config` with `--add-exports` flags when using Java 16+

This is achieved by running the formatter in a java subprocess with the necessary `--add-exports` specified. The forking logic was adapted from https://github.com/spotify/flo/blob/master/flo-runner%2Fsrc%2Fmain%2Fjava%2Fcom%2Fspotify%2Fflo%2Fcontext%2FForkingExecutor.java. We could also consider putting the forking logic in a separate library for easier reuse. Presumably we might encounter the same problem again.

Alternative to https://github.com/spotify/fmt-maven-plugin/pull/139