### PR TITLE
set version to 2.16-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.spotify.fmt</groupId>
     <artifactId>fmt-maven-plugin</artifactId>
-    <version>2.15</version>
+    <version>2.16-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
Maybe the [release process](https://github.com/spotify/fmt-maven-plugin#deploy) should also be updated to use the maven release plugin?