### PR TITLE
Release 2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.spotify.fmt</groupId>
     <artifactId>fmt-maven-plugin</artifactId>
-    <version>2.16-SNAPSHOT</version>
+    <version>2.16</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
Could not use release plugin because of our current branch protection:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project fmt-maven-plugin: Unable to commit files
[ERROR] Provider message:
[ERROR] The git-push command failed.
[ERROR] Command output:
[ERROR] remote: error: GH006: Protected branch update failed for refs/heads/main.
[ERROR] remote: error: At least 1 approving review is required by reviewers with write access.
[ERROR] To github.com:spotify/fmt-maven-plugin.git
[ERROR]  ! [remote rejected] main -> main (protected branch hook declined)
[ERROR] error: failed to push some refs to 'github.com:spotify/fmt-maven-plugin.git'
```