### PR TITLE
Use 2.16 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,10 +174,7 @@
             <plugin>
                 <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.15</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
+                <version>2.16</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Which should automatically fork plugin for JDK 16+
Await the availability of this version in Maven Central.