### PR TITLE
google-java-format 1.15.0 to 1.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>com.google.googlejavaformat</groupId>
             <artifactId>google-java-format</artifactId>
-            <version>1.15.0</version>
+            <version>1.16.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
https://github.com/google/google-java-format/releases/tag/v1.16.0

New changes:

- `/*foo=*/` -> `/* foo= */`
- ` throws Exception0, Exception1, Exception2, Exception3, Exception4, Exception5, Exception6,
          Exception7, Exception8, Exception9 {}` -> 
```      
throws Exception0,
          Exception1,
          Exception2,
          Exception3,
          Exception4,
          Exception5,
          Exception6,
          Exception7,
          Exception8,
          Exception9 {}
```