### PR TITLE
Bump google-java-format to 1.19.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>1.18.1</version>
+      <version>1.19.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description
Bumps google-java-format to 1.19.1 to support new JDK syntax.

## References
https://github.com/google/google-java-format/releases
#182