### PR TITLE
Upgrade Google Java Format 1.21.0 -> 1.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
See:
- https://github.com/google/google-java-format/releases/tag/v1.22.0
- https://github.com/google/google-java-format/compare/v1.21.0...v1.22.0