### PR TITLE
Upgrade Google Java Format 1.24.0 -> 1.25.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '11', '17', '21' ]
+        java: [ '17', '21' ]
         os: [ 'ubuntu-20.04', 'windows-latest' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
As of this release the plugin requires Java 17 or greater. Formatting
Java 11 source files is still supported.

See:
- https://github.com/google/google-java-format/releases/tag/v1.25.0
- https://github.com/google/google-java-format/compare/v1.24.0...v1.25.0