### PR TITLE
Upgrade Google Java Format 1.24.0 -> 1.26.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '11', '17', '21' ]
+        java: [ '17', '21' ]
         os: [ 'ubuntu-20.04', 'windows-latest' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: print Java version
       run: java -version
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         java: [ '17', '21' ]
-        os: [ 'ubuntu-20.04', 'windows-latest' ]
+        os: [ 'ubuntu-24.04', 'windows-latest' ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.2</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </scm>
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>1728284791</project.build.outputTimestamp>
     <maven.version>3.9.6</maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>1.25.2</version>
+      <version>1.26.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Upgrade to latest Google Java Formatter v1.25.2 (https://github.com/google/google-java-format/releases/tag/v1.25.2) 