### PR TITLE
Add skipRemovingUnusedImports and skipReflowingLongStrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ For example, you may prefer that the `check` goal is performed in an earlier pha
 
 `skip` is whether the plugin should skip the operation.
 
+`skipReflowingLongStrings` is whether the plugin should skip reflowing long strings. It defaults to `false`.
+
+`skipRemovingUnusedImports` is whether the plugin should skip removing unused imports. It defaults to `true`.
+
 `skipSortingImports` is whether the plugin should skip sorting imports.
 
 `skipSourceDirectory` is whether the plugin should skip formatting/checking the `sourceDirectory`. It defaults to `false`.
@@ -138,6 +142,8 @@ example:
                 <skipSourceDirectory>false</skipSourceDirectory>
                 <skipTestSourceDirectory>false</skipTestSourceDirectory>
                 <skipSortingImports>false</skipSortingImports>
+                <skipRemovingUnusedImports>true</skipRemovingUnusedImports>
+                <skipReflowingLongStrings>false</skipReflowingLongStrings>
                 <style>google</style>
             </configuration>
             <executions>

--- a/src/main/java/com/spotify/fmt/AbstractFMT.java
+++ b/src/main/java/com/spotify/fmt/AbstractFMT.java
@@ -82,6 +82,12 @@ public abstract class AbstractFMT extends AbstractMojo {
   @Parameter(defaultValue = "false", property = "skipSortingImports")
   private boolean skipSortingImports = false;
 
+  @Parameter(defaultValue = "false", property = "skipRemovingUnusedImports")
+  private boolean skipRemovingUnusedImports = false;
+
+  @Parameter(defaultValue = "true", property = "skipReflowingLongStrings")
+  private boolean skipReflowingLongStrings = true;
+
   @Parameter(defaultValue = "google", property = "style")
   private String style;
 
@@ -121,6 +127,12 @@ public abstract class AbstractFMT extends AbstractMojo {
     if (skipSortingImports) {
       getLog().info("Skipping sorting imports");
     }
+    if (skipRemovingUnusedImports) {
+        getLog().info("Skipping removing unused imports");
+      }
+    if (skipReflowingLongStrings) {
+        getLog().info("Skipping reflowing long strings");
+      }
     List<File> directoriesToFormat = new ArrayList<>();
     if (sourceDirectory.exists() && !skipSourceDirectory) {
       directoriesToFormat.add(sourceDirectory);
@@ -150,6 +162,8 @@ public abstract class AbstractFMT extends AbstractMojo {
             .filesPathPattern(filesPathPattern)
             .verbose(verbose)
             .skipSortingImports(skipSortingImports)
+            .skipRemovingUnusedImports(skipRemovingUnusedImports)
+            .skipReflowingLongStrings(skipReflowingLongStrings)
             .writeReformattedFiles(shouldWriteReformattedFiles())
             .processingLabel(getProcessingLabel())
             .build();

--- a/src/main/java/com/spotify/fmt/Formatter.java
+++ b/src/main/java/com/spotify/fmt/Formatter.java
@@ -33,6 +33,8 @@ import com.google.googlejavaformat.java.ImportOrderer;
 import com.google.googlejavaformat.java.JavaFormatterOptions;
 import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
 import com.google.googlejavaformat.java.RemoveUnusedImports;
+import com.google.googlejavaformat.java.StringWrapper;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -154,9 +156,14 @@ class Formatter {
     try {
       String input = source.read();
       String formatted = formatter.formatSource(input);
-      formatted = RemoveUnusedImports.removeUnusedImports(formatted);
+      if (!cfg.skipRemovingUnusedImports()) {
+          formatted = RemoveUnusedImports.removeUnusedImports(formatted);
+      }
       if (!cfg.skipSortingImports()) {
         formatted = ImportOrderer.reorderImports(formatted, style);
+      }
+      if (!cfg.skipReflowingLongStrings()) {
+          formatted = StringWrapper.wrap(formatted, formatter);
       }
       if (!input.equals(formatted)) {
         if (cfg.writeReformattedFiles()) {

--- a/src/main/java/com/spotify/fmt/FormattingConfiguration.java
+++ b/src/main/java/com/spotify/fmt/FormattingConfiguration.java
@@ -45,6 +45,10 @@ interface FormattingConfiguration extends Serializable {
   String filesPathPattern();
 
   boolean skipSortingImports();
+  
+  boolean skipRemovingUnusedImports();
+  
+  boolean skipReflowingLongStrings();
 
   boolean writeReformattedFiles();
 

--- a/src/main/java/com/spotify/fmt/FormattingConfigurationBuilder.java
+++ b/src/main/java/com/spotify/fmt/FormattingConfigurationBuilder.java
@@ -56,6 +56,10 @@ final class FormattingConfigurationBuilder {
 
   private String processingLabel;
 
+  private boolean skipRemovingUnusedImports;
+
+  private boolean skipReflowingLongStrings;
+
   public FormattingConfigurationBuilder() {
   }
 
@@ -68,6 +72,8 @@ final class FormattingConfigurationBuilder {
     this.filesNamePattern = v.filesNamePattern();
     this.filesPathPattern = v.filesPathPattern();
     this.skipSortingImports = v.skipSortingImports();
+    this.skipRemovingUnusedImports = v.skipRemovingUnusedImports();
+    this.skipReflowingLongStrings = v.skipReflowingLongStrings();
     this.writeReformattedFiles = v.writeReformattedFiles();
     this.processingLabel = v.processingLabel();
   }
@@ -80,6 +86,8 @@ final class FormattingConfigurationBuilder {
     this.filesNamePattern = v.filesNamePattern();
     this.filesPathPattern = v.filesPathPattern();
     this.skipSortingImports = v.skipSortingImports();
+    this.skipRemovingUnusedImports = v.skipRemovingUnusedImports();
+    this.skipReflowingLongStrings = v.skipReflowingLongStrings();
     this.writeReformattedFiles = v.writeReformattedFiles();
     this.processingLabel = v.processingLabel();
   }
@@ -230,9 +238,27 @@ final class FormattingConfigurationBuilder {
     return this;
   }
 
+  public boolean skipRemovingUnusedImports() {
+    return skipRemovingUnusedImports;
+  }
+
+  public FormattingConfigurationBuilder skipRemovingUnusedImports(boolean skipRemovingUnusedImports) {
+    this.skipRemovingUnusedImports = skipRemovingUnusedImports;
+    return this;
+  }
+
+  public boolean skipReflowingLongStrings() {
+    return skipReflowingLongStrings;
+  }
+
+  public FormattingConfigurationBuilder skipReflowingLongStrings(boolean skipReflowingLongStrings) {
+    this.skipReflowingLongStrings = skipReflowingLongStrings;
+    return this;
+  }
+
   public FormattingConfiguration build() {
     List<File> _directoriesToFormat = (directoriesToFormat != null) ? Collections.unmodifiableList(new ArrayList<File>(directoriesToFormat)) : Collections.<File>emptyList();
-    return new Value(debug, style, _directoriesToFormat, verbose, filesNamePattern, filesPathPattern, skipSortingImports, writeReformattedFiles, processingLabel);
+    return new Value(debug, style, _directoriesToFormat, verbose, filesNamePattern, filesPathPattern, skipSortingImports, skipRemovingUnusedImports, skipReflowingLongStrings, writeReformattedFiles, processingLabel);
   }
 
   public static FormattingConfigurationBuilder from(FormattingConfiguration v) {
@@ -262,12 +288,18 @@ final class FormattingConfigurationBuilder {
 
     private final String processingLabel;
 
+    private final boolean skipRemovingUnusedImports;
+
+    private final boolean skipReflowingLongStrings;
+
     private Value(boolean debug,String style,
         List<File> directoriesToFormat,
         boolean verbose,
         String filesNamePattern,
         String filesPathPattern,
         boolean skipSortingImports,
+        boolean skipRemovingUnusedImports,
+        boolean skipReflowingLongStrings,
         boolean writeReformattedFiles,
         String processingLabel) {
       if (style == null) {
@@ -289,6 +321,8 @@ final class FormattingConfigurationBuilder {
       this.filesNamePattern = filesNamePattern;
       this.filesPathPattern = filesPathPattern;
       this.skipSortingImports = skipSortingImports;
+      this.skipRemovingUnusedImports = skipRemovingUnusedImports;
+      this.skipReflowingLongStrings = skipReflowingLongStrings;
       this.writeReformattedFiles = writeReformattedFiles;
       this.processingLabel = processingLabel;
     }
@@ -338,6 +372,16 @@ final class FormattingConfigurationBuilder {
       return processingLabel;
     }
 
+    @Override
+    public boolean skipRemovingUnusedImports() {
+      return skipRemovingUnusedImports;
+    }
+
+    @Override
+    public boolean skipReflowingLongStrings() {
+      return skipReflowingLongStrings;
+    }
+
     public FormattingConfigurationBuilder builder() {
       return new FormattingConfigurationBuilder(this);
     }
@@ -372,6 +416,12 @@ final class FormattingConfigurationBuilder {
       if (skipSortingImports != that.skipSortingImports()) {
         return false;
       }
+      if (skipRemovingUnusedImports != that.skipRemovingUnusedImports()) {
+        return false;
+      }
+      if (skipReflowingLongStrings != that.skipReflowingLongStrings()) {
+        return false;
+      }
       if (writeReformattedFiles != that.writeReformattedFiles()) {
         return false;
       }
@@ -391,6 +441,8 @@ final class FormattingConfigurationBuilder {
       result = 31 * result + (this.filesNamePattern != null ? this.filesNamePattern.hashCode() : 0);
       result = 31 * result + (this.filesPathPattern != null ? this.filesPathPattern.hashCode() : 0);
       result = 31 * result + (this.skipSortingImports ? 1231 : 1237);
+      result = 31 * result + (this.skipRemovingUnusedImports ? 1231 : 1237);
+      result = 31 * result + (this.skipReflowingLongStrings ? 1231 : 1237);
       result = 31 * result + (this.writeReformattedFiles ? 1231 : 1237);
       result = 31 * result + (this.processingLabel != null ? this.processingLabel.hashCode() : 0);
       return result;
@@ -406,6 +458,8 @@ final class FormattingConfigurationBuilder {
       ", filesNamePattern=" + filesNamePattern +
       ", filesPathPattern=" + filesPathPattern +
       ", skipSortingImports=" + skipSortingImports +
+      ", skipRemovingUnusedImports=" + skipRemovingUnusedImports +
+      ", skipReflowingLongStrings=" + skipReflowingLongStrings +
       ", writeReformattedFiles=" + writeReformattedFiles +
       ", processingLabel=" + processingLabel +
       '}';


### PR DESCRIPTION
Add support for additional Google Java Format options

  Summary

  - Add skipRemovingUnusedImports configuration option to control unused import removal
  - Add skipReflowingLongStrings configuration option to control string wrapping behavior

  Changes Made

  - New configuration options: Added two new boolean parameters to control formatting behavior
    - skipRemovingUnusedImports - defaults to false (removes unused imports by default)
    - skipReflowingLongStrings - defaults to true (skips string reflowing for backwards compatibility)
  - Documentation: Updated README.md with configuration examples and descriptions for new options
  - Maven integration: Added new parameters to AbstractFMT with proper @Parameter annotations

  Backwards Compatibility

  - skipReflowingLongStrings defaults to true to maintain existing behavior
  - skipRemovingUnusedImports defaults to false to maintain existing import removal behavior
  - All existing configurations continue to work without changes

Closes #197 