### PR TITLE
Fix defaults mentioned in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ For example, you may prefer that the `check` goal is performed in an earlier pha
 
 `skip` is whether the plugin should skip the operation.
 
-`skipReflowingLongStrings` is whether the plugin should skip reflowing long strings. It defaults to `false`.
+`skipReflowingLongStrings` is whether the plugin should skip reflowing long strings. It defaults to `true`.
 
-`skipRemovingUnusedImports` is whether the plugin should skip removing unused imports. It defaults to `true`.
+`skipRemovingUnusedImports` is whether the plugin should skip removing unused imports. It defaults to `false`.
 
 `skipSortingImports` is whether the plugin should skip sorting imports.
 
@@ -142,8 +142,8 @@ example:
                 <skipSourceDirectory>false</skipSourceDirectory>
                 <skipTestSourceDirectory>false</skipTestSourceDirectory>
                 <skipSortingImports>false</skipSortingImports>
-                <skipRemovingUnusedImports>true</skipRemovingUnusedImports>
-                <skipReflowingLongStrings>false</skipReflowingLongStrings>
+                <skipRemovingUnusedImports>false</skipRemovingUnusedImports>
+                <skipReflowingLongStrings>true</skipReflowingLongStrings>
                 <style>google</style>
             </configuration>
             <executions>


### PR DESCRIPTION
The defaults of the new `skipReflowingLongStrings` and
`skipRemovingUnusedImports` settings are the other way around.